### PR TITLE
Fix hero overflow on mobile

### DIFF
--- a/components/hero-code-themed.tsx
+++ b/components/hero-code-themed.tsx
@@ -147,7 +147,7 @@ export function HeroCodeThemed() {
 
   return (
     <section
-      className="relative min-h-screen flex items-center justify-center
+      className="relative min-h-screen flex items-center justify-center overflow-hidden
                  bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900"
     >
       {/* Animated Background Grid */}


### PR DESCRIPTION
## Summary
- stop hero section elements from overflowing on small screens

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68401255a7a88331aabd04be2281e59f