### PR TITLE
Add inline images to three articles

### DIFF
--- a/content/blog/advanced-lstm-forecasting.md
+++ b/content/blog/advanced-lstm-forecasting.md
@@ -12,6 +12,8 @@ coverImage: "/blog/lstm-forecasting.png"
 
 Time-series forecasting using deep learning has advanced significantly in recent years. Long Short-Term Memory (LSTM) networks excel at modeling sequential data with complex temporal dependencies.
 
+![LSTM forecasting architecture](/streaming-analytics-architecture.png)
+
 ## Why LSTM?
 
 LSTMs address the vanishing gradient problem found in standard recurrent networks by introducing gating mechanisms that regulate information flow. This makes them ideal for forecasting tasks where long-term patterns matter.

--- a/content/blog/data-mesh-architecture.md
+++ b/content/blog/data-mesh-architecture.md
@@ -25,6 +25,8 @@ seo:
 
 Data mesh is a paradigm shift in how we think about and implement data platforms in large organizations. It moves away from the centralized data lake or data warehouse approach to a distributed architecture that treats data as a product, owned by domain teams.
 
+![Data mesh architecture diagram](/data-mesh-architecture.png)
+
 ## The Problem with Traditional Data Architectures
 
 Traditional data architectures often suffer from several challenges:

--- a/content/blog/kubernetes-operators-data-pipelines.md
+++ b/content/blog/kubernetes-operators-data-pipelines.md
@@ -12,6 +12,8 @@ coverImage: "/blog/k8s-operators-data-pipelines.png"
 
 Kubernetes Operators enable you to extend the cluster's capabilities by encoding domain-specific knowledge into custom controllers.
 
+![Kubernetes cluster diagram](/kubernetes-cluster-diagram.png)
+
 ## Operator Pattern
 
 Operators build on custom resources to manage stateful applications. They watch the Kubernetes API and reconcile the cluster to the desired state.


### PR DESCRIPTION
## Summary
- embed a data mesh architecture diagram in the data mesh article
- include a Kubernetes cluster diagram in the operators article
- add a forecasting architecture image in the LSTM article

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a14689308331b85c030276642a49